### PR TITLE
Add support for ARM64V8 architecture

### DIFF
--- a/fetch-cirros.sh
+++ b/fetch-cirros.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
-VERSION=0.3.4
-URL=https://download.cirros-cloud.net/${VERSION}/cirros-${VERSION}-x86_64-lxc.tar.gz
+VERSION=0.4.0
+ARCH="$(uname -m)"
+URL=https://download.cirros-cloud.net/${VERSION}/cirros-${VERSION}-${ARCH}-lxc.tar.gz
 wget $URL
+sed -i "s/cirros-0.3.4-x86_64-lxc.tar.gz/cirros-$VERSION-$ARCH-lxc.tar.gz/g" Dockerfile


### PR DESCRIPTION
Reference: https://github.com/ewindisch/docker-cirros/issues/5 

This PR has been raised to extend support for ```ARM64``` architecture.
The changes are done to fetch rootfs according to host architecture and modify dockerfile accordingly.
user will run:
```
fetch-cirros.sh
docker build
```
Signed-off-by: Odidev <odidev@puresoftware.com>